### PR TITLE
Admin sessions takeda

### DIFF
--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,10 +1,6 @@
 class Admin < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, #:registerable,
          :recoverable, :rememberable, :validatable
 end

--- a/app/views/admins/sessions/new.html.erb
+++ b/app/views/admins/sessions/new.html.erb
@@ -1,26 +1,15 @@
-<h2>Log in</h2>
-
+<h2>管理者ログイン</h2>
+    
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+   <%= f.label :"メールアドレス" %><br />
+   <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
-
   <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
+  <%= f.label :"パスワード" %><br />
+  <%= f.password_field :password, autocomplete: "current-password" %>
   </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
-
   <div class="actions">
-    <%= f.submit "Log in" %>
+    <%= f.submit "　ログイン　", class: "btn btn-primary" %>
   </div>
 <% end %>
-
-<%= render "admins/shared/links" %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,8 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+Admin.create!(
+    email: 'admin@mail',
+    password: 'adminpass'
+  )


### PR DESCRIPTION
新規登録機能削除　ルーティングエラーになると思います。
ログインページビュー変更
adminアカウント追加　（rails db:seedする必要があると思います）
adminアカウント名は　　email:admin@mail　、password: adminpass　　seed.rbの中にも見れます。
現状admin ログインすると　<%= link_to ' 注文履歴一覧', admin_orders_path %>にエラーが出ます　
消せばログアウトできます
何がつけ忘れてたら教えてください。